### PR TITLE
Use https by default (since access to the API by HTTP will be disabled on 4/27)

### DIFF
--- a/pagerduty_icinga.pl
+++ b/pagerduty_icinga.pl
@@ -97,7 +97,7 @@ pagerduty_icinga flush [options]
 # Debian Sarge (Perl 5.8.4)
 # Ubuntu 9.04  (Perl 5.10.0)
 
-my $opt_api_base = "http://events.pagerduty.com/nagios/2010-04-15";
+my $opt_api_base = "https://events.pagerduty.com/nagios/2010-04-15";
 my %opt_fields;
 my $opt_help;
 my $opt_queue_dir = "/tmp/pagerduty_icinga";


### PR DESCRIPTION
Since access to the API will be disabled on 4/27 the Icinga integration that are linked from the integration guide should use https.
